### PR TITLE
fix: fix @commitlint/core imports

### DIFF
--- a/src/lint-commits.plugin.js
+++ b/src/lint-commits.plugin.js
@@ -1,6 +1,11 @@
 import * as config from '@commitlint/config-conventional';
-import { format, lint, load } from '@commitlint/core';
+import * as commitlint from '@commitlint/core';
 import SemanticReleaseError from '@semantic-release/error';
+
+import interopRequireDefault from '@babel/runtime/helpers/interopRequireDefault';
+const format = interopRequireDefault(commitlint.format).default,
+  lint = interopRequireDefault(commitlint.lint).default,
+  load = interopRequireDefault(commitlint.load).default;
 
 export async function verifyRelease(repoData, options) {
   return validateCommits(options);


### PR DESCRIPTION
The commitlint core doesn't correctly export the default exports from its constituent dependencies.

ref conventional-changelog/commitlint#645