### PR TITLE
Fix error formatting while validating commits

### DIFF
--- a/src/lint-commits.plugin.js
+++ b/src/lint-commits.plugin.js
@@ -35,8 +35,8 @@ async function validateCommit(commitMeta, opts, logger) {
     const detail = commitMeta.commit.short ? ` ${commitMeta.commit.short}` : '';
     logger.error(`😞   Errors found with commit${detail}`);
     logger.error(`💬   ${commitMeta.message}`);
-    const formatted = format({ errors: report.errors });
-    formatted.forEach((item) => logger.log(item));
+    const formatted = format({ results: [report] });
+    logger.log(formatted);
     throw new SemanticReleaseError(
       `The commit message is not formatted correctly`,
       'EINVALIDCOMMIT'


### PR DESCRIPTION
the [@commitlint/format](https://commitlint.js.org/#/reference-api?id=commitlintformat) signature here 
it's likely that the forked project used an older version of `@commitlint/core` that had a different function signature.